### PR TITLE
Allow Hash#smash to include the options

### DIFF
--- a/lib/flatten/hash.rb
+++ b/lib/flatten/hash.rb
@@ -1,5 +1,5 @@
 class Hash
-	def smash(options = {}
+	def smash(options = {})
 		Flatten(self, options)
 	end
 end

--- a/lib/flatten/hash.rb
+++ b/lib/flatten/hash.rb
@@ -1,5 +1,5 @@
 class Hash
-	def smash
+	def smash(options = {}
 		Flatten(self)
 	end
 end

--- a/lib/flatten/hash.rb
+++ b/lib/flatten/hash.rb
@@ -1,5 +1,5 @@
 class Hash
 	def smash(options = {}
-		Flatten(self)
+		Flatten(self, options)
 	end
 end


### PR DESCRIPTION
it would be nice to be able to call `hash.smash(smash_array: true)` instead of having to do `Flatten.smash(hash, smash_array: true)`